### PR TITLE
Add dialect metadata file for IDE integration

### DIFF
--- a/src/main/resources/org/thymeleaf/extras/java8time/Java8Time.xml
+++ b/src/main/resources/org/thymeleaf/extras/java8time/Java8Time.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+   Copyright 2016, The Thymeleaf Project (http://www.thymeleaf.org/)
+   
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+   
+       http://www.apache.org/licenses/LICENSE-2.0
+   
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<dialect xmlns="http://www.thymeleaf.org/extras/dialect"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.thymeleaf.org/extras/dialect
+	                    http://www.thymeleaf.org/xsd/thymeleaf-extras-dialect-2.1.xsd"
+	prefix="java8time"
+	namespace-uri="http://www.thymeleaf.org/extras/java8time"
+	namespace-strict="false"
+	class="org.thymeleaf.extras.java8time.dialect.Java8TimeDialect">
+
+	<expression-object name="temporals" class="org.thymeleaf.extras.java8time.expression.Temporals">
+		<documentation reference="Java 8 Time module readme"><![CDATA[
+			<a href="https://github.com/thymeleaf/thymeleaf-extras-java8time">https://github.com/thymeleaf/thymeleaf-extras-java8time</a>
+		]]></documentation>
+	</expression-object>
+
+</dialect>


### PR DESCRIPTION
Hey @jmiguelsamper, I've been going through the Thymeleaf dialects to update the dialect metadata file for Thymeleaf 3.0 that we have to work with the Eclipse plugin (https://github.com/thymeleaf/thymeleaf/issues/454).  I recently saw a tweet showcasing that the next version of IntelliJ also makes use of these files to aid with its autocomplete feature, so it's gonna be useful for IntelliJ too! :grin: 

This project was missing one, so I've got this PR to add it.  PR made against the 3.0-dev branch.

/cc @danielfernandez 
