### PR TITLE
Return null in formatting methods for a null Temporal

### DIFF
--- a/src/main/java/org/thymeleaf/extras/java8time/util/TemporalFormattingUtils.java
+++ b/src/main/java/org/thymeleaf/extras/java8time/util/TemporalFormattingUtils.java
@@ -55,12 +55,10 @@ public final class TemporalFormattingUtils {
     }
 
     public String format(final Object target) {
-        Validate.notNull(target, "Cannot apply format on null");
         return formatDate(target);
     }
 
     public String format(final Object target, final Locale locale) {
-        Validate.notNull(target, "Cannot apply format on null");
         Validate.notNull(locale, "Locale cannot be null");
         return formatDate(target, null, locale);
     }
@@ -70,82 +68,94 @@ public final class TemporalFormattingUtils {
     }
 
     public String format(final Object target, final String pattern, final Locale locale) {
-        Validate.notNull(target, "Cannot apply format on null");
         Validate.notEmpty(pattern, "Pattern cannot be null or empty");
         return formatDate(target, pattern, locale);
     }
 
     public Integer day(final Object target) {
-        Validate.notNull(target, "Cannot retrieve day from null");
+        if (target == null) {
+            return null;
+        }
         final TemporalAccessor time = temporal(target);
         return time.get(ChronoField.DAY_OF_MONTH);
     }
 
     public Integer month(final Object target) {
-        Validate.notNull(target, "Cannot retrieve month from null");
+        if (target == null) {
+            return null;
+        }
         final TemporalAccessor time = temporal(target);
         return time.get(ChronoField.MONTH_OF_YEAR);
     }
 
     public String monthName(final Object target) {
-        Validate.notNull(target, "Cannot retrieve month name from null");
         return format(target, "MMMM");
     }
 
     public String monthNameShort(final Object target) {
-        Validate.notNull(target, "Cannot retrieve month name short from null");
         return format(target, "MMM");
     }
 
     public Integer year(final Object target) {
-        Validate.notNull(target, "Cannot retrieve year from null");
+        if (target == null) {
+            return null;
+        }
         final TemporalAccessor time = temporal(target);
         return time.get(ChronoField.YEAR);
     }
 
     public Integer dayOfWeek(final Object target) {
-        Validate.notNull(target, "Cannot retrieve day of week from null");
+        if (target == null) {
+            return null;
+        }
         final TemporalAccessor time = temporal(target);
         return time.get(ChronoField.DAY_OF_WEEK);
     }
 
     public String dayOfWeekName(final Object target) {
-        Validate.notNull(target, "Cannot retrieve day of week name from null");
         return format(target, "EEEE");
     }
 
     public String dayOfWeekNameShort(final Object target) {
-        Validate.notNull(target, "Cannot retrieve day of week name shortfrom null");
         return format(target, "EEE");
     }
 
     public Integer hour(final Object target) {
-        Validate.notNull(target, "Cannot retrieve hour from null");
+        if (target == null) {
+            return null;
+        }
         final TemporalAccessor time = temporal(target);
         return time.get(ChronoField.HOUR_OF_DAY);
     }
 
     public Integer minute(final Object target) {
-        Validate.notNull(target, "Cannot retrieve hour from null");
+        if (target == null) {
+            return null;
+        }
         final TemporalAccessor time = temporal(target);
         return time.get(ChronoField.MINUTE_OF_HOUR);
     }
 
     public Integer second(final Object target) {
-        Validate.notNull(target, "Cannot retrieve hour from null");
+        if (target == null) {
+            return null;
+        }
         final TemporalAccessor time = temporal(target);
         return time.get(ChronoField.SECOND_OF_MINUTE);
     }
 
     public Integer nanosecond(final Object target) {
-        Validate.notNull(target, "Cannot retrieve hour from null");
+        if (target == null) {
+            return null;
+        }
         final TemporalAccessor time = temporal(target);
         return time.get(ChronoField.NANO_OF_SECOND);
     }
 
     public String formatISO(final Object target) {
-        Validate.notNull(target, "Cannot apply format on null");
-        if (target instanceof TemporalAccessor) {
+        if (target == null) {
+            return null;
+        } else if (target instanceof TemporalAccessor) {
             ChronoZonedDateTime time = zonedTime(target, defaultZoneId);
             return ISO8601_DATE_TIME_FORMATTER.withLocale(locale).format(time);
         } else {
@@ -159,10 +169,11 @@ public final class TemporalFormattingUtils {
     }
 
     private String formatDate(final Object target, final String pattern, final Locale localeOverride) {
+        if (target == null) {
+            return null;
+        }
         Locale formattingLocale = localeOverride != null ? localeOverride : locale;
         try {
-            Validate.notNull(target, "Cannot apply format on null");
-
             DateTimeFormatter formatter;
             if (StringUtils.isEmptyOrWhitespace(pattern)) {
                 formatter = TemporalObjects.formatterFor(target, formattingLocale);

--- a/src/test/java/org/thymeleaf/extras/java8time/expression/TemporalsFormattingTest.java
+++ b/src/test/java/org/thymeleaf/extras/java8time/expression/TemporalsFormattingTest.java
@@ -38,9 +38,19 @@ public class TemporalsFormattingTest {
     }
     
     @Test
+    public void testFormatWithNullTemporal() {
+        assertNull(temporals.format(null));
+    }
+
+    @Test
     public void testFormatWithLocale() {
         Temporal time = ZonedDateTime.of(2015, 12, 31, 23, 59, 45, 0, ZoneOffset.UTC);
         assertEquals("31. Dezember 2015 23:59:45 Z", temporals.format(time, Locale.GERMAN));
+    }
+
+    @Test
+    public void testFormatWithLocaleAndNullTemporal() {
+        assertNull(temporals.format(null, Locale.GERMAN));
     }
 
     @Test
@@ -52,11 +62,21 @@ public class TemporalsFormattingTest {
     }
 
     @Test
+    public void testFormatWithPatternAndNullTemporal() {
+        assertNull(temporals.format(null, "y"));
+    }
+
+    @Test
     public void testFormatWithPatternAndLocale() {
         Temporal time = LocalDateTime.of(2015, 12, 31, 23, 59);
         String pattern = "EEEE, d MMMM, yyyy";
         String expectd = "Donnerstag, 31 Dezember, 2015";
         assertEquals(expectd, temporals.format(time, pattern, Locale.GERMAN));
+    }
+
+    @Test
+    public void testFormatWithPatternAndLocaleAndNullTemporal() {
+        assertNull(temporals.format(null, "y", Locale.GERMAN));
     }
 
     @Test
@@ -66,15 +86,30 @@ public class TemporalsFormattingTest {
     }
 
     @Test
+    public void testDayWithNullTemporal() {
+        assertNull(temporals.day(null));
+    }
+
+    @Test
     public void testMonth() {
         Temporal time = LocalDate.of(2015, 12, 31);
         assertEquals(12, temporals.month(time).intValue());
     }
     
     @Test
+    public void testMonthWithNullTemporal() {
+        assertNull(temporals.month(null));
+    }
+
+    @Test
     public void testMonthName() {
         Temporal time = LocalDate.of(2015, 12, 31);
         assertEquals("December", temporals.monthName(time));
+    }
+
+    @Test
+    public void testMonthNameWithNullTemporal() {
+        assertNull(temporals.monthName(null));
     }
 
     @Test
@@ -84,9 +119,19 @@ public class TemporalsFormattingTest {
     }
 
     @Test
+    public void testMonthNameShortWithNullTemporal() {
+        assertNull(temporals.monthNameShort(null));
+    }
+
+    @Test
     public void testYear() {
         Temporal time = LocalDate.of(2015, 12, 31);
         assertEquals(2015, temporals.year(time).intValue());
+    }
+
+    @Test
+    public void testYearWithNullTemporal() {
+        assertNull(temporals.year(null));
     }
 
     @Test
@@ -96,11 +141,21 @@ public class TemporalsFormattingTest {
     }
     
     @Test
+    public void testDayOfWeekWithNullTemporal() {
+        assertNull(temporals.dayOfWeek(null));
+    }
+
+    @Test
     public void testDayOfWeekName() {
         Temporal time = LocalDate.of(2015, 12, 31);
         assertEquals("Thursday", temporals.dayOfWeekName(time));
     }
     
+    @Test
+    public void testDayOfWeekNameWithNullTemporal() {
+        assertNull(temporals.dayOfWeekName(null));
+    }
+
     @Test
     public void testDayOfWeekNameShort() {
         Temporal time = LocalDate.of(2015, 12, 31);
@@ -108,9 +163,19 @@ public class TemporalsFormattingTest {
     }
     
     @Test
+    public void testDayOfWeekNameShortWithNullTemporal() {
+        assertNull(temporals.dayOfWeekNameShort(null));
+    }
+
+    @Test
     public void testHour() {
         Temporal time = LocalDateTime.of(2015, 12, 31, 23, 59, 45, 1);
         assertEquals(23, temporals.hour(time).intValue());
+    }
+
+    @Test
+    public void testHourWithNullTemporal() {
+        assertNull(temporals.hour(null));
     }
 
     @Test
@@ -120,9 +185,19 @@ public class TemporalsFormattingTest {
     }
 
     @Test
+    public void testMinuteWithNullTemporal() {
+        assertNull(temporals.minute(null));
+    }
+
+    @Test
     public void testSecond() {
         Temporal time = LocalDateTime.of(2015, 12, 31, 23, 59, 45, 1);
         assertEquals(45, temporals.second(time).intValue());
+    }
+
+    @Test
+    public void testSecondWithNullTemporal() {
+        assertNull(temporals.second(null));
     }
 
     @Test
@@ -132,9 +207,19 @@ public class TemporalsFormattingTest {
     }
 
     @Test
+    public void testNanosecondWithNullTemporal() {
+        assertNull(temporals.nanosecond(null));
+    }
+
+    @Test
     public void testFormatISO() {
         Temporal time = LocalDateTime.of(2015, 12, 31, 23, 59, 45, 1).atZone(ZoneOffset.MAX);
         assertEquals("2015-12-31T23:59:45.000+1800", temporals.formatISO(time));
+    }
+
+    @Test
+    public void testFormatISOWithNullTemporal() {
+        assertNull(temporals.formatISO(null));
     }
 
 }


### PR DESCRIPTION
Resolution for much-voted issue #14 that I encountered today, bringing behaviour of all formatting methods (`#temporals.format()`, `#temporals.day()` etc.) in line with Thymeleaf core `#dates` methods by returning `null` when the supplied `Temporal` parameter is `null`.