### PR TITLE
Add .withZone(defaultZoneId) in TemporalFormattingUtils.formatDate

### DIFF
--- a/src/main/java/org/thymeleaf/extras/java8time/util/TemporalFormattingUtils.java
+++ b/src/main/java/org/thymeleaf/extras/java8time/util/TemporalFormattingUtils.java
@@ -179,7 +179,7 @@ public final class TemporalFormattingUtils {
                 formatter = TemporalObjects.formatterFor(target, formattingLocale);
                 return formatter.format(temporal(target));
             } else {
-                formatter = DateTimeFormatter.ofPattern(pattern, formattingLocale);
+                formatter = DateTimeFormatter.ofPattern(pattern, formattingLocale).withZone(defaultZoneId);
                 return formatter.format(temporal(target));
             }
         } catch (final Exception e) {

--- a/src/test/java/org/thymeleaf/extras/java8time/expression/TemporalsFormattingTest.java
+++ b/src/test/java/org/thymeleaf/extras/java8time/expression/TemporalsFormattingTest.java
@@ -15,14 +15,18 @@
  */
 package org.thymeleaf.extras.java8time.expression;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.Temporal;
 import java.util.Locale;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * Tests regarding formatting of temporal objects.
@@ -222,4 +226,15 @@ public class TemporalsFormattingTest {
         assertNull(temporals.formatISO(null));
     }
 
+    @Test
+    public void testFormatInstant() throws Exception {
+        Instant instant = Instant.ofEpochMilli(1503561536699L);
+        assertEquals("2017-08-24T07:58:56.699Z", temporals.format(instant));
+    }
+
+    @Test
+    public void testFormatInstantWithPattern() throws Exception {
+        Instant instant = Instant.ofEpochMilli(1503561536699L);
+        assertEquals("2017-08-24", temporals.format(instant, "yyyy-MM-dd"));
+    }
 }

--- a/src/test/java/org/thymeleaf/extras/java8time/expression/TemporalsFormattingTest.java
+++ b/src/test/java/org/thymeleaf/extras/java8time/expression/TemporalsFormattingTest.java
@@ -15,8 +15,6 @@
  */
 package org.thymeleaf.extras.java8time.expression;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -27,6 +25,7 @@ import java.time.temporal.Temporal;
 import java.util.Locale;
 
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * Tests regarding formatting of temporal objects.
@@ -40,7 +39,7 @@ public class TemporalsFormattingTest {
         Temporal time = ZonedDateTime.of(2015, 12, 31, 23, 59, 45, 0, ZoneOffset.UTC);
         assertEquals("December 31, 2015 11:59:45 PM Z", temporals.format(time));
     }
-    
+
     @Test
     public void testFormatWithNullTemporal() {
         assertNull(temporals.format(null));


### PR DESCRIPTION
Add .withZone(defaultZoneId) in TemporalFormattingUtils.formatDate method's DateTimeFormatter to support format a java.time.Instant. 
Fix #17