### PR TITLE
Fixing conversion of OffsetDateTime temporal objects

### DIFF
--- a/src/main/java/org/thymeleaf/extras/java8time/util/TemporalObjects.java
+++ b/src/main/java/org/thymeleaf/extras/java8time/util/TemporalObjects.java
@@ -109,6 +109,8 @@ public final class TemporalObjects {
             return ZonedDateTime.of((LocalDate) target, LocalTime.MIDNIGHT, defaultZoneId);
         } else if (target instanceof Instant) {
             return ZonedDateTime.ofInstant((Instant) target, defaultZoneId);
+        } else if (target instanceof OffsetDateTime) {
+            return ((OffsetDateTime) target).toZonedDateTime();
         } else {
             throw new IllegalArgumentException(
                 "Cannot format object of class \"" + target.getClass().getName() + "\" as a date");

--- a/src/test/java/org/thymeleaf/extras/java8time/expression/TemporalsFormattingTest.java
+++ b/src/test/java/org/thymeleaf/extras/java8time/expression/TemporalsFormattingTest.java
@@ -91,6 +91,11 @@ public class TemporalsFormattingTest {
         assertEquals("23:59:45", temporals.format(time, "HH:mm:ss"));
     }
     
+    @Test
+    public void offsetDateTimeWithPattern() {
+        OffsetDateTime odt = OffsetDateTime.of(LocalDateTime.of(2015, 12, 31, 23, 59, 45), ZoneOffset.UTC);
+        assertEquals("12/31/2015 23:59:45", temporals.format(odt, "MM/dd/yyyy HH:mm:ss"));
+    }
 
     @Test
     public void testDay() {


### PR DESCRIPTION
Adds conversion support for OffsetDateTime objects. Includes a test case. Previously the IllegalArgumentException was thrown when trying to format OffsetDateTime objects.